### PR TITLE
Fix graphviz labels which aren't simple tokens

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -1,5 +1,3 @@
 (library
  (public_name focs)
- (libraries jupyter.notebook))
-
-
+ (libraries re jupyter.notebook))

--- a/lib/tree.ml
+++ b/lib/tree.ml
@@ -4,14 +4,27 @@ let rec string_of (str_of_alpha : 'a -> string) : 'a t -> string = function
     | Lf -> "Lf"
     | Br(x,l,r) -> Printf.sprintf "Br(%s,%s,%s)" (str_of_alpha x) (string_of str_of_alpha l) (string_of str_of_alpha r)
 
+let dot_escape =
+  let re = Re.(compile @@ char '"') in
+  fun oc s ->
+    (* Allow HTML strings - put everything else in double-quotes, which is safe.
+       See https://graphviz.org/doc/info/lang.html *)
+    let s =
+      if String.length s = 0 || s.[0] <> '<' then
+        "\"" ^ Re.replace_string re ~by:"\\\"" s ^ "\""
+      else
+        s
+    in
+      output_string oc s
+
 let printer (str_of_alpha : 'a -> string) (x : 'a t) =
   let filename,oc = Filename.open_temp_file "tree" ".dot" in
   Printf.fprintf oc "digraph D {\n";
   let rec dump_nodes n = function
     | Lf -> Printf.fprintf oc "  Lf%d [label=\"Lf\"]\n" n
     | Br (x,t1,t2) ->
-      Printf.fprintf oc "  Br%d [label=%s]\n" n (str_of_alpha x);
-        dump_nodes (2*n+1) t1; 
+      Printf.fprintf oc "  Br%d [label=%a]\n" n dot_escape (str_of_alpha x);
+        dump_nodes (2*n+1) t1;
         dump_nodes (2*n+2) t2
   in
   dump_nodes 0 x;
@@ -46,5 +59,3 @@ let printer (str_of_alpha : 'a -> string) (x : 'a t) =
 let rec preorder = function
   | Lf -> []
   | Br(x,l,r) -> x :: preorder l @ preorder r
-
-


### PR DESCRIPTION
Allows anything to be given as the label, including `<<b>crazy</b> HTML examples>`!